### PR TITLE
Clean up code, fix gemspec

### DIFF
--- a/bonsai-elasticsearch-rails.gemspec
+++ b/bonsai-elasticsearch-rails.gemspec
@@ -49,8 +49,8 @@ Gem::Specification.new do |spec|
 
   # This gem simply requires the listed gems to be installed, the actual version
   # does not matter. `gem build` throws an error if a version range is not
-  # specified, so it's set arbitrarily high. If Elastic ever introduces a
-  # breaking change to client instantiation, this will be updated.
+  # specified, so it's set arbitrarily high. For more information, see:
+  # https://github.com/omc/bonsai-elasticsearch-rails/pull/6
   spec.add_runtime_dependency 'elasticsearch-model', '< 99'
   spec.add_runtime_dependency 'elasticsearch-rails', '< 99'
 

--- a/bonsai-elasticsearch-rails.gemspec
+++ b/bonsai-elasticsearch-rails.gemspec
@@ -1,55 +1,60 @@
-# coding: utf-8
+# rubocop:disable Metrics/BlockLength
 Gem::Specification.new do |spec|
-  spec.name          = "bonsai-elasticsearch-rails"
-  spec.version       = "0.2.0"
+  spec.name          = 'bonsai-elasticsearch-rails'
+  spec.version       = '0.3.0'
 
-  spec.authors       = ["Rob Sears", "Nick Zadrozny"]
-  spec.email         = ["rob@onemorecloud.com", "nick@onemorecloud.com"]
+  spec.authors       = ['Rob Sears', 'Nick Zadrozny']
+  spec.email         = ['rob@onemorecloud.com', 'nick@onemorecloud.com']
 
-  spec.summary       = "Integrate your elasticsearch-rails gem with Bonsai Elasticsearch."
-  spec.description   = <<-EOF
-                          This gem offers a shim to connect Rails apps with a Bonsai
-                          Elasticsearch cluster. The official Elasticsearch gem package
-                          requires some minor configuration tweaks in order to work
-                          correctly with Bonsai (namely the client needs to be instantiated
-                          with the cluster location and HTTP authentication details), and
-                          the process can be somewhat complicated for users who are
-                          unfamiliar with the system.
+  spec.summary       = 'Initialize your Elasticsearch client with Bonsai.'
+  spec.description   = <<-DESCRIPTION
+  This gem offers a shim to connect Rails apps with a Bonsai
+  Elasticsearch cluster. The official Elasticsearch gem package
+  requires some minor configuration tweaks in order to work
+  correctly with Bonsai (namely the client needs to be instantiated
+  with the cluster location and HTTP authentication details), and
+  the process can be somewhat complicated for users who are
+  unfamiliar with the system.
 
-                          The bonsai-elasticsearch-rails gem automatically sets up the
-                          Elasticsearch client correctly so users don't need to worry about
-                          configuring it in their code or writing an initializer.
+  The bonsai-elasticsearch-rails gem automatically sets up the
+  Elasticsearch client correctly so users don't need to worry about
+  configuring it in their code or writing an initializer.
 
-                          In order for the gem to work correctly, the application needs an
-                          environment variable called `BONSAI_URL`, which is populated with
-                          the complete Bonsai Elaticsearch cluster URL, including the HTTP
-                          authentication. The cluster URL will follow this pattern:
+  In order for the gem to work correctly, the application needs an
+  environment variable called `BONSAI_URL`, which is populated with
+  the complete Bonsai Elaticsearch cluster URL, including the HTTP
+  authentication. The cluster URL will follow this pattern:
 
-                          https://user1234:pass5678@cluster-slug-123.aws-region-X.bonsai.io/
+  https://user1234:pass5678@cluster-slug-123.aws-region-X.bonsai.io/
 
-                          On Heroku, this variable is created and populated automatically
-                          when Bonsai is added to the application. Heroku users therefore do
-                          not need to perform any additional configuration to connect to
-                          their cluster after adding the bonsai-elasticsearch-rails gem.
+  On Heroku, this variable is created and populated automatically
+  when Bonsai is added to the application. Heroku users therefore do
+  not need to perform any additional configuration to connect to
+  their cluster after adding the bonsai-elasticsearch-rails gem.
 
-                          Users who are self-hosting their Rails app will need to make sure
-                          this environment variable is present:
+  Users who are self-hosting their Rails app will need to make sure
+  this environment variable is present:
 
-                          export BONSAI_URL="https://user1234:pass5678@aws-region-X.bonsai.io/"
+  export BONSAI_URL="https://user1234:pass5678@aws-region-X.bonsai.io/"
 
-                          The cluster URL is available via the Bonsai dashboard.
-                       EOF
+  The cluster URL is available via the Bonsai dashboard.
+  DESCRIPTION
 
-  spec.homepage      = "https://github.com/omc/bonsai-elasticsearch-rails"
-  spec.license       = "MIT"
+  spec.homepage      = 'https://github.com/omc/bonsai-elasticsearch-rails'
+  spec.license       = 'MIT'
 
-  spec.files         = [ "lib/bonsai-elasticsearch-rails.rb", "lib/bonsai/elasticsearch/rails/railtie.rb" ]
-  spec.require_paths = [ "lib" ]
+  spec.files         = ['lib/bonsai-elasticsearch-rails.rb',
+                        'lib/bonsai/elasticsearch/rails/railtie.rb']
+  spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency "elasticsearch-model", "~> 0"
-  spec.add_runtime_dependency "elasticsearch-rails", "~> 0"
+  # This gem simply requires the listed gems to be installed, the actual version
+  # does not matter. `gem build` throws an error if a version range is not
+  # specified, so it's set arbitrarily high. If Elastic ever introduces a
+  # breaking change to client instantiation, this will be updated.
+  spec.add_runtime_dependency 'elasticsearch-model', '< 99'
+  spec.add_runtime_dependency 'elasticsearch-rails', '< 99'
 
-  spec.add_development_dependency "bundler", "~> 1"
-  spec.add_development_dependency "rake", "< 11.0"
-
+  spec.add_development_dependency 'bundler', '~> 1'
+  spec.add_development_dependency 'rake', '< 11.0'
 end
+# rubocop:enable Metrics/BlockLength

--- a/lib/bonsai-elasticsearch-rails.rb
+++ b/lib/bonsai-elasticsearch-rails.rb
@@ -1,3 +1,4 @@
 if defined?(Rails)
-  require File.expand_path('bonsai/elasticsearch/rails/railtie', File.dirname(__FILE__))
+  require File.expand_path('bonsai/elasticsearch/rails/railtie',
+                           File.dirname(__FILE__))
 end

--- a/lib/bonsai/elasticsearch/rails/railtie.rb
+++ b/lib/bonsai/elasticsearch/rails/railtie.rb
@@ -1,10 +1,9 @@
 module Bonsai
   module Elasticsearch
     module Rails
+      # Use Railties
       class Railtie < ::Rails::Railtie
-
         config.after_initialize do
-
           require 'elasticsearch/model'
           require 'elasticsearch/rails'
 
@@ -13,19 +12,20 @@ module Bonsai
 
           begin
             if url && URI.parse(url)
-              filtered_url = url.sub(%r{:[^:@]+@}, ':FILTERED@')
-              logger.debug("Bonsai: Initializing default Elasticsearch client with #{filtered_url}")
+              filtered_url = url.sub(/:[^:@]+@/, ':FILTERED@')
+              logger.debug('Bonsai: Initializing default Elasticsearch client'\
+                           " with #{filtered_url}")
               ::Elasticsearch::Model.client = ::Elasticsearch::Client.new(
                 url: url
               )
             elsif ::Rails.env.production?
-              logger.debug("BONSAI_URL not present, proceeding with Elasticsearch defaults.")
+              logger.debug('BONSAI_URL not present, proceeding with'\
+                           'Elasticsearch defaults.')
             end
           rescue URI::InvalidURIError => e
             logger.error("Elasticsearch cluster URL is invalid: #{e.message}")
           end
         end
-
       end
     end
   end


### PR DESCRIPTION
This gem is a little unusual in the sense that it does not really require any particular version of the elasticsearch-rails gem, and should work with any version thereof. However, if a version is not specified, then `gem build` complains about open-ended dependencies and recommends the "twiddle-wakka" operator (`'~> 0'`). 

This causes some problems because, as mentioned in issue #5, it is essentially setting the range of supported Elasticsearch-rails gem versions to >=0 and <1, which breaks for any app needing Elasticsearch 2.x and higher.

It's annoying because there isn't a great option for solving this that I'm aware of; I don't like the idea of suppressing warnings anymore than the idea of ignoring them. The official client [available through RubyGems](https://rubygems.org/gems/elasticsearch-rails/) is also a full version behind the current version of Elasticsearch, and will be 2 versions behind once ES 7.x ships (it's currently in alpha).

This means that in order to make this gem track the version of the official client, it would need to access and inspect the GitHub project, which isn't straightforward like [Gem.latest_spec_for](https://apidock.com/ruby/Gem/latest_spec_for/class). It's supposedly impossible to do directly, and I don't want to hack on workarounds.

The compromise I'm making here is to update the master branch of this gem to support all versions of elasticsearch-rails and elasticsearch-model below 99.0.0. While this reeks of code smell, it's probably the least-bad option:

* It builds without errors or warnings
* It doesn't require suppressing warnings
* It gives users the ability to use whatever version of the client they want in their Gemfile
* It will work for the foreseeable future.

In addition, I'll be creating more branches in this project for each major version of Elasticsearch, and will be using the proper versions in the gemspec. This will allow users to install specific versions of this gem, which will have appropriate dependencies set for the Elasticsearch gems.